### PR TITLE
Adds skip root deployment and version warning

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -89,21 +89,21 @@ type Package struct {
 
 // readConfigToml reads the config.toml file and upgrade config according to content
 type Config struct {
-	Name       string             `toml:"name"`
-	Workspace  string             `toml:"workspace"`
-	Type       string             `toml:"type"`
-	Protocol   string             `toml:"protocol"`
-	Functions  []string           `toml:"functions"`
-	Models     []string           `toml:"models"`
-	Agents     []string           `toml:"agents"`
-	Entrypoint Entrypoints        `toml:"entrypoint"`
-	Env        Envs               `toml:"env"`
-	Function   map[string]Package `toml:"function"`
-	Agent      map[string]Package `toml:"agent"`
-
-	Runtime  *map[string]interface{}   `toml:"runtime"`
-	Triggers *[]map[string]interface{} `toml:"triggers"`
-	Policies []string                  `toml:"policies,omitempty"`
+	Name       string                    `toml:"name"`
+	Workspace  string                    `toml:"workspace"`
+	Type       string                    `toml:"type"`
+	Protocol   string                    `toml:"protocol"`
+	Functions  []string                  `toml:"functions"`
+	Models     []string                  `toml:"models"`
+	Agents     []string                  `toml:"agents"`
+	Entrypoint Entrypoints               `toml:"entrypoint"`
+	Env        Envs                      `toml:"env"`
+	Function   map[string]Package        `toml:"function"`
+	Agent      map[string]Package        `toml:"agent"`
+	SkipRoot   bool                      `toml:"skipRoot"`
+	Runtime    *map[string]interface{}   `toml:"runtime"`
+	Triggers   *[]map[string]interface{} `toml:"triggers"`
+	Policies   []string                  `toml:"policies,omitempty"`
 }
 
 func readConfigToml() {

--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -417,7 +417,7 @@ func getDeployCommands(dryRun bool, defaultName string) ([]PackageCommand, error
 		Name:    "root",
 		Cwd:     pwd,
 		Command: "bl",
-		Args:    []string{"deploy", "--recursive=false"},
+		Args:    []string{"deploy", "--recursive=false", "--skip-version-warning"},
 	}
 	if dryRun {
 		command.Args = append(command.Args, "--dryrun")
@@ -425,8 +425,10 @@ func getDeployCommands(dryRun bool, defaultName string) ([]PackageCommand, error
 	if defaultName != "" {
 		command.Args = append(command.Args, "--name", defaultName)
 	}
-	commands := []PackageCommand{command}
-
+	commands := []PackageCommand{}
+	if !config.SkipRoot {
+		commands = append(commands, command)
+	}
 	packages := getAllPackages()
 	for name, pkg := range packages {
 		command := PackageCommand{
@@ -436,6 +438,7 @@ func getDeployCommands(dryRun bool, defaultName string) ([]PackageCommand, error
 			Args: []string{
 				"deploy",
 				"--recursive=false",
+				"--skip-version-warning",
 			},
 		}
 		if dryRun {

--- a/cli/root.go
+++ b/cli/root.go
@@ -185,10 +185,16 @@ var version string
 var commit string
 var date string
 var utc bool
+var skipVersionWarning bool
 var rootCmd = &cobra.Command{
 	Use:   "bl",
 	Short: "Blaxel CLI is a command line tool to interact with Blaxel APIs.",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// Check for updates in a goroutine to not block the main execution
+		if !skipVersionWarning {
+			checkForUpdates(version)
+		}
+
 		setEnvs()
 
 		readSecrets()
@@ -275,6 +281,7 @@ func Execute(releaseVersion string, releaseCommit string, releaseDate string) er
 	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "", "Output format. One of: pretty,yaml,json,table")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
 	rootCmd.PersistentFlags().BoolVarP(&utc, "utc", "u", false, "Enable UTC timezone")
+	rootCmd.PersistentFlags().BoolVarP(&skipVersionWarning, "skip-version-warning", "", false, "Skip version warning")
 
 	if workspace == "" {
 		workspace = sdk.CurrentContext().Workspace
@@ -288,9 +295,5 @@ func Execute(releaseVersion string, releaseCommit string, releaseDate string) er
 	if date == "" {
 		date = releaseDate
 	}
-
-	// Check for updates in a goroutine to not block the main execution
-	checkForUpdates(version)
-
 	return rootCmd.Execute()
 }

--- a/cli/serve_package.go
+++ b/cli/serve_package.go
@@ -142,13 +142,16 @@ func getServeCommands(port int, host string, hotreload bool) ([]PackageCommand, 
 		Name:    "root",
 		Cwd:     pwd,
 		Command: "bl",
-		Args:    []string{"serve", "--port", fmt.Sprintf("%d", port), "--host", host, "--recursive=false"},
+		Args:    []string{"serve", "--port", fmt.Sprintf("%d", port), "--host", host, "--recursive=false", "--skip-version-warning"},
 		Color:   colors[0],
 	}
 	if hotreload {
 		command.Args = append(command.Args, "--hotreload")
 	}
-	commands := []PackageCommand{command}
+	commands := []PackageCommand{}
+	if !config.SkipRoot {
+		commands = append(commands, command)
+	}
 	i := 1
 	for name, pkg := range packages {
 		if pkg.Port == 0 {
@@ -172,6 +175,7 @@ func getServeCommands(port int, host string, hotreload bool) ([]PackageCommand, 
 				"--host",
 				host,
 				"--recursive=false",
+				"--skip-version-warning",
 			},
 			Color: colors[i%len(colors)],
 		}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.2
 
 require (
 	github.com/BurntSushi/toml v1.3.2
+	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/beamlit/toolkit v0.1.12
 	github.com/charmbracelet/bubbles v0.20.0
 	github.com/charmbracelet/glamour v0.8.0
@@ -20,7 +21,6 @@ require (
 )
 
 require (
-	github.com/Masterminds/semver/v3 v3.3.1 // indirect
 	github.com/alecthomas/chroma/v2 v2.14.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59 // indirect


### PR DESCRIPTION
Allows skipping deployment of the root package and disables the version check warning.

This change introduces a `skipRoot` configuration option in `config.toml`.
If set to true, the root package will be excluded from the deployment process.

Adds a `--skip-version-warning` flag to suppress version update notifications.
Also, version warning check is now skipped in `PersistentPreRunE` if flag is set.
