### PR TITLE
Allows specifying multiple env files and secrets

### DIFF
--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -460,6 +460,12 @@ func getDeployCommands(dryRun bool, defaultName string) ([]PackageCommand, error
 		if dryRun {
 			command.Args = append(command.Args, "--dryrun")
 		}
+		for _, envFile := range envFiles {
+			command.Args = append(command.Args, "--env-file", envFile)
+		}
+		for _, secret := range secrets {
+			command.Args = append(command.Args, "-s", fmt.Sprintf("%s=%s", secret.Name, secret.Value))
+		}
 		commands = append(commands, command)
 	}
 	return commands, nil

--- a/cli/secret.go
+++ b/cli/secret.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/joho/godotenv"
 )
@@ -13,6 +14,20 @@ type Secrets []Env
 
 var secrets Secrets
 
+func loadCommandSecrets() {
+	for _, secret := range commandSecrets {
+		parts := strings.Split(secret, "=")
+		if len(parts) != 2 {
+			fmt.Println("Invalid secret format", secret)
+			continue
+		}
+		secrets = append(secrets, Env{
+			Name:  parts[0],
+			Value: parts[1],
+		})
+	}
+}
+
 func readSecrets(folder string) {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -20,16 +35,16 @@ func readSecrets(folder string) {
 		return
 	}
 
-	envMap, err := godotenv.Read(filepath.Join(cwd, folder, ".env"))
-	if err != nil {
-		return
+	for _, file := range envFiles {
+		envMap, err := godotenv.Read(filepath.Join(cwd, folder, file))
+		if err != nil {
+			return
+		}
+		for key, value := range envMap {
+			secrets = append(secrets, Env{
+				Name:  key,
+				Value: value,
+			})
+		}
 	}
-
-	for key, value := range envMap {
-		secrets = append(secrets, Env{
-			Name:  key,
-			Value: value,
-		})
-	}
-
 }

--- a/cli/serve_package.go
+++ b/cli/serve_package.go
@@ -182,6 +182,12 @@ func getServeCommands(port int, host string, hotreload bool) ([]PackageCommand, 
 		if hotreload {
 			command.Args = append(command.Args, "--hotreload")
 		}
+		for _, envFile := range envFiles {
+			command.Args = append(command.Args, "--env-file", envFile)
+		}
+		for _, secret := range secrets {
+			command.Args = append(command.Args, "-s", fmt.Sprintf("%s=%s", secret.Name, secret.Value))
+		}
 		commands = append(commands, command)
 		i++
 	}


### PR DESCRIPTION
Enables the application to load multiple environment files
through the --env-file flag. Also introduces the ability to
pass secrets directly via the command line using the -s flag.
This provides more flexibility in configuring the application
and managing sensitive information.
