### PR TITLE
Remove recursive if deploy include folder

### DIFF
--- a/cli/server/commands.go
+++ b/cli/server/commands.go
@@ -69,7 +69,11 @@ func GetServerEnvironment(port int, host string, hotreload bool, config core.Con
 	env.AddClientEnv()
 	env.Set("BL_SERVER_PORT", fmt.Sprintf("%d", port))
 	env.Set("BL_SERVER_HOST", host)
-	env.Set("BL_WORKSPACE", config.Workspace)
+	workspace := config.Workspace
+	if workspace == "" {
+		workspace = core.GetWorkspace()
+	}
+	env.Set("BL_WORKSPACE", workspace)
 	env.Set("PATH", os.Getenv("PATH"))
 	if hotreload {
 		env.Set("BL_HOTRELOAD", "true")


### PR DESCRIPTION
Ensures the application uses the default workspace directory
if no workspace is specified in the configuration file.

This prevents potential issues when the configuration is incomplete.
