### PR TITLE
Allow to set env in blaxelConfig to set dev environment

### DIFF
--- a/cli/core/root.go
+++ b/cli/core/root.go
@@ -212,19 +212,23 @@ func isNewerVersion(latestVersion, currentVersion string) bool {
 	return latest.GreaterThan(current)
 }
 
-func init() {
-	env := os.Getenv("BL_ENV")
-	if env == "dev" {
+func initEnv(env string) {
+	switch env {
+	case "dev":
 		BASE_URL = "https://api.blaxel.dev/v0"
 		APP_URL = "https://app.blaxel.dev"
 		RUN_URL = "https://run.blaxel.dev"
 		REGISTRY_URL = "https://eu.registry.blaxel.dev"
-	} else if env == "local" {
+	case "local":
 		BASE_URL = "http://localhost:8080/v0"
 		APP_URL = "http://localhost:3000"
 		RUN_URL = "https://run.blaxel.dev"
 		REGISTRY_URL = "https://eu.registry.blaxel.dev"
 	}
+}
+
+func init() {
+	initEnv(os.Getenv("BL_ENV"))
 }
 
 var envFiles []string
@@ -340,6 +344,8 @@ func Execute(releaseVersion string, releaseCommit string, releaseDate string) er
 
 	if workspace == "" {
 		workspace = sdk.CurrentContext().Workspace
+		env := sdk.LoadEnv(workspace)
+		initEnv(env)
 	}
 	if version == "" {
 		version = releaseVersion

--- a/sdk/credentials.go
+++ b/sdk/credentials.go
@@ -83,6 +83,20 @@ func LoadCredentials(workspaceName string) Credentials {
 	return Credentials{}
 }
 
+func LoadEnv(workspaceName string) string {
+	config := loadConfig()
+	for _, workspace := range config.Workspaces {
+		if workspace.Name == workspaceName {
+			return workspace.Env
+		}
+	}
+	env := os.Getenv("BL_ENV")
+	if env != "" {
+		return env
+	}
+	return "prod"
+}
+
 func createHomeDirIfMissing() {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {

--- a/sdk/types.go
+++ b/sdk/types.go
@@ -7,6 +7,7 @@ type Config struct {
 type WorkspaceConfig struct {
 	Name        string      `yaml:"name"`
 	Credentials Credentials `yaml:"credentials"`
+	Env         string      `yaml:"env"`
 }
 
 type ContextConfig struct {


### PR DESCRIPTION
Add a feature to remove the need of switch, usefull to not demo with a bug :)

```
- name: charles-dev
  credentials:
    apiKey: ""
    access_token: xxx
    refresh_token: xxx
    expires_in: 7200
    device_code: xxx
    client_credentials: ""
  **env: dev**
- name: charles-prod
  credentials:
    apiKey: ""
    access_token:  xxx
    refresh_token: xxx
    expires_in: 7200
    device_code: xxx
    client_credentials: ""
  env: ""
  
  ```