### PR TITLE
Adds automatic blaxel.toml configuration

### DIFF
--- a/cli/core/render.go
+++ b/cli/core/render.go
@@ -21,7 +21,7 @@ func getImageColumnWidth() int {
 	width, _, err := term.GetSize(int(os.Stdout.Fd()))
 	if err != nil {
 		// Fallback to default if we can't get terminal size
-		return 25
+		return 100
 	}
 
 	// Calculate space used by other columns (with some padding for separators and margins)

--- a/cli/createagentapp.go
+++ b/cli/createagentapp.go
@@ -131,6 +131,7 @@ bl create-agent-app my-agent-app --template template-google-adk-py -y`,
 				}
 			}
 			core.CleanTemplate(opts.Directory)
+			_ = core.EditBlaxelTomlInCurrentDir("agent", opts.ProjectName, opts.Directory)
 			fmt.Printf(`Your blaxel agent app has been created. Start working on it:
 cd %s;
 bl serve --hotreload;

--- a/cli/createmcpserver.go
+++ b/cli/createmcpserver.go
@@ -133,6 +133,7 @@ bl create-mcp-server my-mcp-server --template template-mcp-hello-world-py -y`,
 				}
 			}
 			core.CleanTemplate(opts.Directory)
+			_ = core.EditBlaxelTomlInCurrentDir("function", opts.ProjectName, opts.Directory)
 			fmt.Printf(`Your blaxel mcp server has been created. Start working on it:
 cd %s;
 bl serve --hotreload;


### PR DESCRIPTION
Adds automatic configuration of `blaxel.toml` when creating agent apps and MCP servers.

- Simplifies the setup process by automatically appending resource configurations to the `blaxel.toml` file, including the resource type, name, path, and an automatically assigned port number.
- Implements a port assignment system to avoid port conflicts, starting from port 1340 and incrementing until an available port is found.